### PR TITLE
Add URL errors report page

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -228,6 +228,9 @@ html_template = f"""<!DOCTYPE html>
             >
               Consultations Tracker Report
             </gcds-nav-link>
+            <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/url_errors.html">
+              URL Errors Report
+            </gcds-nav-link>
             <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/changelog.html">
               Change Log Report
             </gcds-nav-link>
@@ -330,7 +333,7 @@ html_template = f"""<!DOCTYPE html>
 with open("report.html", "w", encoding="utf-8") as f:
     f.write(html_template)
 
-# Create the final HTML page by injecting the tables into a template.
+# Create the change log HTML page by injecting the tables into a template.
 chng_log_template = f"""<!DOCTYPE html>
 <html dir="ltr" lang="en">
   <head>
@@ -414,6 +417,9 @@ chng_log_template = f"""<!DOCTYPE html>
             <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/report.html">
               Consultations Tracker Report
             </gcds-nav-link>
+            <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/url_errors.html">
+              URL Errors Report
+            </gcds-nav-link>
             <gcds-nav-link
               href="https://patlittle.github.io/Consultations-Tracker/changelog.html"
               current
@@ -453,6 +459,132 @@ chng_log_template = f"""<!DOCTYPE html>
 </html>
 """
 
-# Write the final HTML into a file.
+# Create the URL errors HTML page with the same layout as the change log.
+url_errors_template = f"""<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Report highlighting consultation URL errors sourced from the Consultations Tracker."
+    />
+    <title>Consultations URL Errors Report</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.alpha.canada.ca/@gcds-core/css-shortcuts@1.0.1/dist/gcds-css-shortcuts.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@0.43.1/dist/gcds/gcds.css"
+    />
+    <script
+      type="module"
+      src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@0.43.1/dist/gcds/gcds.esm.js"
+    ></script>
+    <style>
+      .page-layout {{
+        display: grid;
+        gap: 2rem;
+      }}
+
+      @media (min-width: 64em) {{
+        .page-layout {{
+          grid-template-columns: minmax(220px, 280px) 1fr;
+        }}
+      }}
+
+      .side-nav {{
+        position: sticky;
+        top: 2rem;
+        align-self: start;
+      }}
+
+      .page-content > section + section {{
+        margin-block-start: 2rem;
+      }}
+
+      .iframe-wrapper {{
+        margin-block-start: 2rem;
+      }}
+
+      .iframe-wrapper iframe {{
+        width: 100%;
+        min-height: 70vh;
+        border: none;
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+      }}
+    </style>
+  </head>
+  <body>
+    <gcds-header
+      lang-href="https://patlittle.github.io/Consultations-Tracker/url_errors.html"
+      skip-to-href="#main-content"
+    >
+      <gcds-breadcrumbs slot="breadcrumb">
+        <gcds-breadcrumbs-item href="https://patlittle.github.io/Consultations-Tracker/">
+          Consultations Tracker
+        </gcds-breadcrumbs-item>
+        <gcds-breadcrumbs-item href="https://patlittle.github.io/Consultations-Tracker/url_errors.html">
+          URL Errors Report
+        </gcds-breadcrumbs-item>
+      </gcds-breadcrumbs>
+    </gcds-header>
+    <gcds-container
+      id="main-content"
+      main-container
+      size="xl"
+      centered
+      tag="main"
+    >
+      <div class="page-layout">
+        <aside class="side-nav" aria-label="Consultations Tracker navigation">
+          <gcds-side-nav label="Consultations Tracker navigation">
+            <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/report.html">
+              Consultations Tracker Report
+            </gcds-nav-link>
+            <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/url_errors.html" current>
+              URL Errors Report
+            </gcds-nav-link>
+            <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/changelog.html">
+              Change Log Report
+            </gcds-nav-link>
+            <gcds-nav-link href="https://open.canada.ca/data/en/dataset/7c03f039-3753-4093-af60-74b0f7b2385d">
+              Source Open Data Set
+            </gcds-nav-link>
+            <gcds-nav-link href="https://www.canada.ca/en/government/system/consultations/consultingcanadians.html">
+              Consulting with Canadians
+            </gcds-nav-link>
+          </gcds-side-nav>
+        </aside>
+        <div class="page-content">
+          <section>
+            <gcds-heading tag="h1">Consultations URL Errors Report</gcds-heading>
+
+            <gcds-notice type="success" notice-title-tag="h2" notice-title="Report Generated">
+              <gcds-text>{generated_datetime_str}</gcds-text>
+            </gcds-notice>
+
+
+          </section>
+          <section class="iframe-wrapper">
+            <iframe
+              src="https://flatgithub.com/PatLittle/Consultations-Tracker/blob/master/bad-urls.csv?filename=bad-urls.csv"
+              title="Consultations Tracker URL errors table"
+            ></iframe>
+          </section>
+          <gcds-date-modified>{generated_date_str}</gcds-date-modified>
+        </div>
+      </div>
+    </gcds-container>
+    <gcds-footer display="simple"></gcds-footer>
+  </body>
+</html>
+"""
+
+# Write the final HTML files.
 with open("changelog.html", "w", encoding="utf-8") as f:
     f.write(chng_log_template)
+
+with open("url_errors.html", "w", encoding="utf-8") as f:
+    f.write(url_errors_template)

--- a/report.html
+++ b/report.html
@@ -113,6 +113,9 @@
             >
               Consultations Tracker Report
             </gcds-nav-link>
+            <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/url_errors.html">
+              URL Errors Report
+            </gcds-nav-link>
             <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/changelog.html">
               Change Log Report
             </gcds-nav-link>

--- a/url_errors.html
+++ b/url_errors.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Change log view of consultation updates sourced from the Consultations Tracker."
+      content="Report highlighting consultation URL errors sourced from the Consultations Tracker."
     />
-    <title>Consultations Change Log Report</title>
+    <title>Consultations URL Errors Report</title>
     <link
       rel="stylesheet"
       href="https://cdn.design-system.alpha.canada.ca/@gcds-core/css-shortcuts@1.0.1/dist/gcds-css-shortcuts.min.css"
@@ -56,15 +56,15 @@
   </head>
   <body>
     <gcds-header
-      lang-href="https://patlittle.github.io/Consultations-Tracker/changelog.html"
+      lang-href="https://patlittle.github.io/Consultations-Tracker/url_errors.html"
       skip-to-href="#main-content"
     >
       <gcds-breadcrumbs slot="breadcrumb">
         <gcds-breadcrumbs-item href="https://patlittle.github.io/Consultations-Tracker/">
           Consultations Tracker
         </gcds-breadcrumbs-item>
-        <gcds-breadcrumbs-item href="https://patlittle.github.io/Consultations-Tracker/changelog.html">
-          Change Log Report
+        <gcds-breadcrumbs-item href="https://patlittle.github.io/Consultations-Tracker/url_errors.html">
+          URL Errors Report
         </gcds-breadcrumbs-item>
       </gcds-breadcrumbs>
     </gcds-header>
@@ -81,13 +81,10 @@
             <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/report.html">
               Consultations Tracker Report
             </gcds-nav-link>
-            <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/url_errors.html">
+            <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/url_errors.html" current>
               URL Errors Report
             </gcds-nav-link>
-            <gcds-nav-link
-              href="https://patlittle.github.io/Consultations-Tracker/changelog.html"
-              current
-            >
+            <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/changelog.html">
               Change Log Report
             </gcds-nav-link>
             <gcds-nav-link href="https://open.canada.ca/data/en/dataset/7c03f039-3753-4093-af60-74b0f7b2385d">
@@ -100,18 +97,18 @@
         </aside>
         <div class="page-content">
           <section>
-            <gcds-heading tag="h1">Consultations Change Log Report</gcds-heading>
-           
+            <gcds-heading tag="h1">Consultations URL Errors Report</gcds-heading>
+
             <gcds-notice type="success" notice-title-tag="h2" notice-title="Report Generated">
               <gcds-text>2025-11-20 00:46:42</gcds-text>
             </gcds-notice>
-            
-         
+
+
           </section>
           <section class="iframe-wrapper">
             <iframe
-              src="https://flatgithub.com/PatLittle/Consultations-Tracker/blob/master/consultations_chng_log.csv?filename=consultations_chng_log.csv&sort=row_chng_datetime%2Cdesc&stickyColumnName=row_chng_datetime"
-              title="Consultations Tracker change log table"
+              src="https://flatgithub.com/PatLittle/Consultations-Tracker/blob/master/bad-urls.csv?filename=bad-urls.csv"
+              title="Consultations Tracker URL errors table"
             ></iframe>
           </section>
           <gcds-date-modified>2025-11-20</gcds-date-modified>


### PR DESCRIPTION
## Summary
- add navigation links to a new URL Errors report alongside existing report pages
- generate the URL errors HTML page mirroring the change log layout with the bad URLs iframe source
- update static report and change log pages to reference the new report in the side navigation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e722deccc8331b6dac6c36f61854a)