### PR TITLE
Add same-tab fullscreen overlay for FlatGithub viewer and new consultations dataset page

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -52,6 +52,32 @@
         border: none;
         box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
       }
+
+      .viewer-controls {
+        margin-block-start: 1rem;
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .viewer-overlay {
+        position: fixed;
+        inset: 0;
+        background: #ffffff;
+        z-index: 9999;
+        padding: 1rem;
+        display: none;
+      }
+
+      .viewer-overlay.active {
+        display: block;
+      }
+
+      .viewer-overlay iframe {
+        width: 100%;
+        height: calc(100vh - 4rem);
+        border: none;
+      }
     </style>
   </head>
   <body>
@@ -90,6 +116,9 @@
             >
               Change Log Report
             </gcds-nav-link>
+            <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/consultations_dataset.html">
+              Consultations Data View
+            </gcds-nav-link>
             <gcds-nav-link href="https://open.canada.ca/data/en/dataset/7c03f039-3753-4093-af60-74b0f7b2385d">
               Source Open Data Set
             </gcds-nav-link>
@@ -108,16 +137,53 @@
             
          
           </section>
-          <section class="iframe-wrapper">
+                    <section class="iframe-wrapper">
             <iframe
+              id="embedded-flat-viewer"
               src="https://flatgithub.com/PatLittle/Consultations-Tracker/blob/master/consultations_chng_log.csv?filename=consultations_chng_log.csv&sort=row_chng_datetime%2Cdesc&stickyColumnName=row_chng_datetime"
               title="Consultations Tracker change log table"
             ></iframe>
+            <div class="viewer-controls">
+              <gcds-button id="open-fullscreen">Open full screen table view</gcds-button>
+              <gcds-button id="open-filter" button-role="secondary">Open Filter Builder</gcds-button>
+            </div>
           </section>
+          <div id="viewer-overlay" class="viewer-overlay" aria-hidden="true">
+            <gcds-button id="close-fullscreen" button-role="secondary">Return to standard view</gcds-button>
+            <iframe id="overlay-flat-viewer" src="https://flatgithub.com/PatLittle/Consultations-Tracker/blob/master/consultations_chng_log.csv?filename=consultations_chng_log.csv&sort=row_chng_datetime%2Cdesc&stickyColumnName=row_chng_datetime" title="Consultations Tracker change log table full screen"></iframe>
+          </div>
+
           <gcds-date-modified>2026-05-04</gcds-date-modified>
         </div>
       </div>
     </gcds-container>
     <gcds-footer display="simple"></gcds-footer>
-  </body>
+  
+    <script>
+      const overlay = document.getElementById("viewer-overlay");
+      const openBtn = document.getElementById("open-fullscreen");
+      const closeBtn = document.getElementById("close-fullscreen");
+      const filterBtn = document.getElementById("open-filter");
+      const iframe = document.getElementById("embedded-flat-viewer");
+      const overlayIframe = document.getElementById("overlay-flat-viewer");
+      const FILTER_HASH = "#schema=builder";
+
+      openBtn?.addEventListener("click", () => {
+        overlay.classList.add("active");
+        overlay.setAttribute("aria-hidden", "false");
+      });
+
+      closeBtn?.addEventListener("click", () => {
+        overlay.classList.remove("active");
+        overlay.setAttribute("aria-hidden", "true");
+      });
+
+      filterBtn?.addEventListener("click", () => {
+        const url = new URL(iframe.src);
+        url.hash = FILTER_HASH.replace("#", "");
+        iframe.src = url.toString();
+        overlayIframe.src = url.toString();
+      });
+    </script>
+</body>
 </html>

--- a/consultations_dataset.html
+++ b/consultations_dataset.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Report highlighting consultation URL errors sourced from the Consultations Tracker."
+      content="Change log view of consultation updates sourced from the Consultations Tracker."
     />
-    <title>Consultations URL Errors Report</title>
+    <title>Consultations Data Set Report</title>
     <link
       rel="stylesheet"
       href="https://cdn.design-system.alpha.canada.ca/@gcds-core/css-shortcuts@1.0.1/dist/gcds-css-shortcuts.min.css"
@@ -82,15 +82,15 @@
   </head>
   <body>
     <gcds-header
-      lang-href="https://patlittle.github.io/Consultations-Tracker/url_errors.html"
+      lang-href="https://patlittle.github.io/Consultations-Tracker/consultations_dataset.html"
       skip-to-href="#main-content"
     >
       <gcds-breadcrumbs slot="breadcrumb">
         <gcds-breadcrumbs-item href="https://patlittle.github.io/Consultations-Tracker/">
           Consultations Tracker
         </gcds-breadcrumbs-item>
-        <gcds-breadcrumbs-item href="https://patlittle.github.io/Consultations-Tracker/url_errors.html">
-          URL Errors Report
+        <gcds-breadcrumbs-item href="https://patlittle.github.io/Consultations-Tracker/consultations_dataset.html">
+          Consultations Data View
         </gcds-breadcrumbs-item>
       </gcds-breadcrumbs>
     </gcds-header>
@@ -107,13 +107,13 @@
             <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/report.html">
               Consultations Tracker Report
             </gcds-nav-link>
-            <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/url_errors.html" current>
+            <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/url_errors.html">
               URL Errors Report
             </gcds-nav-link>
             <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/changelog.html">
               Change Log Report
             </gcds-nav-link>
-            <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/consultations_dataset.html">
+            <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/consultations_dataset.html" current>
               Consultations Data View
             </gcds-nav-link>
             <gcds-nav-link href="https://open.canada.ca/data/en/dataset/7c03f039-3753-4093-af60-74b0f7b2385d">
@@ -126,19 +126,19 @@
         </aside>
         <div class="page-content">
           <section>
-            <gcds-heading tag="h1">Consultations URL Errors Report</gcds-heading>
-
+            <gcds-heading tag="h1">Consultations Data Set Report</gcds-heading>
+           
             <gcds-notice type="success" notice-title-tag="h2" notice-title="Report Generated">
               <gcds-text>2026-05-04 20:12:48</gcds-text>
             </gcds-notice>
-
-
+            
+         
           </section>
                     <section class="iframe-wrapper">
             <iframe
               id="embedded-flat-viewer"
-              src="https://flatgithub.com/PatLittle/Consultations-Tracker/blob/master/bad-urls.csv?filename=bad-urls.csv"
-              title="Consultations Tracker URL errors table"
+              src="https://flatgithub.com/PatLittle/Consultations-Tracker/blob/master/consultations.csv?filename=consultations.csv&stickyColumnName=registration_number"
+              title="Consultations Tracker consultations data table"
             ></iframe>
             <div class="viewer-controls">
               <gcds-button id="open-fullscreen">Open full screen table view</gcds-button>
@@ -147,7 +147,7 @@
           </section>
           <div id="viewer-overlay" class="viewer-overlay" aria-hidden="true">
             <gcds-button id="close-fullscreen" button-role="secondary">Return to standard view</gcds-button>
-            <iframe id="overlay-flat-viewer" src="https://flatgithub.com/PatLittle/Consultations-Tracker/blob/master/bad-urls.csv?filename=bad-urls.csv" title="Consultations Tracker URL errors table full screen"></iframe>
+            <iframe id="overlay-flat-viewer" src="https://flatgithub.com/PatLittle/Consultations-Tracker/blob/master/consultations.csv?filename=consultations.csv&stickyColumnName=registration_number" title="Consultations Tracker consultations data table full screen"></iframe>
           </div>
 
           <gcds-date-modified>2026-05-04</gcds-date-modified>

--- a/report.html
+++ b/report.html
@@ -119,6 +119,9 @@
             <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/changelog.html">
               Change Log Report
             </gcds-nav-link>
+            <gcds-nav-link href="https://patlittle.github.io/Consultations-Tracker/consultations_dataset.html">
+              Consultations Data View
+            </gcds-nav-link>
             <gcds-nav-link href="https://open.canada.ca/data/en/dataset/7c03f039-3753-4093-af60-74b0f7b2385d">
               Consultations Open Dataset
             </gcds-nav-link>


### PR DESCRIPTION
### Motivation
- The embedded FlatGithub table viewer is narrow on-report and makes wide tables uncomfortable to read, so provide an in-page fullscreen overlay to view tables without opening a new tab.  
- Provide a direct way to open the FlatGithub filter/query builder so users can compose searches/filters already supported by the viewer without navigating away.  
- Expose the repository `consultations.csv` as a dedicated report page to make the dataset itself easy to browse alongside the existing reports.  

### Description
- Add a small viewer UI and overlay implementation (CSS + HTML + JS) that opens a fixed, same-tab fullscreen iframe and a `Return to standard view` button, applied to `changelog.html` and `url_errors.html`.  
- Add an `Open Filter Builder` action that appends the FlatGithub builder hash (`#schema=builder`) to the embedded iframe URL and synchronizes the overlay iframe.  
- Add a new page `consultations_dataset.html` that mirrors the FlatGithub embed layout and controls and targets `consultations.csv` in the repository.  
- Update `report.html` and the other report pages to add navigation links to the new `Consultations Data View` page.  

### Testing
- Inspected generated HTML for the three modified pages using `sed`/`nl` to verify the new `.viewer-controls`, overlay markup, and script are present (succeeded).  
- Searched the repository with `rg` to confirm the new IDs and class names (`consultations_dataset`, `open-fullscreen`, `open-filter`, `viewer-overlay`) are present across files (succeeded).  
- Ran `git status` to confirm the working tree contained the intended changes (succeeded).  
- Attempted to fetch the Open Canada datastore CSV via `curl`/Python to source `consultations.csv` automatically but received HTTP 403 from this environment, so the new page is wired to the repository copy (`consultations.csv`) rather than an automated remote download (fetch failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90d63deb88331978f3545e265c88f)